### PR TITLE
Fix image generation path

### DIFF
--- a/src/main/java/nic/com/Diplomka/config/MvcConfig.java
+++ b/src/main/java/nic/com/Diplomka/config/MvcConfig.java
@@ -9,6 +9,6 @@ public class MvcConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers (ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/image_db/**")
-                .addResourceLocations("file:///D:/Programing/Java/MavenNeironka/src/main/resources/resources/image_db/");
+                .addResourceLocations("file:src/main/resources/image_db/");
     }
 }

--- a/src/main/java/nic/com/Diplomka/service/GeneratorService.java
+++ b/src/main/java/nic/com/Diplomka/service/GeneratorService.java
@@ -20,9 +20,14 @@ public class GeneratorService {
 		return Math.hypot(ac, cb);
 	}
 
-	public static void generateImages() {
-		BufferedImage bufferedImageHSB = new BufferedImage(weightImage, heightImage, BufferedImage.TYPE_INT_RGB);
-		BufferedImage bufferedImageRGB = new BufferedImage(weightImage, heightImage, BufferedImage.TYPE_INT_RGB);
+        public static void generateImages() {
+                BufferedImage bufferedImageHSB = new BufferedImage(weightImage, heightImage, BufferedImage.TYPE_INT_RGB);
+                BufferedImage bufferedImageRGB = new BufferedImage(weightImage, heightImage, BufferedImage.TYPE_INT_RGB);
+
+                File dir = new File("src/main/resources/image_db");
+                if (!dir.exists()) {
+                        dir.mkdirs();
+                }
 
 		for (int b = 0; b < builderCount; b++) {
 
@@ -40,8 +45,8 @@ public class GeneratorService {
 					bufferedImageRGB.setRGB(j, i, colorRGB.getRGB());
 				}
 			}
-			saveImage("src\\\\main\\\\resources\\\\image_db\\\\" + b + "_hsb.png", bufferedImageHSB, "png");
-			saveImage("src\\\\main\\\\resources\\\\image_db\\\\" + b + "_rgb.png", bufferedImageRGB, "png");
+                        saveImage("src/main/resources/image_db/" + b + "_hsb.png", bufferedImageHSB, "png");
+                        saveImage("src/main/resources/image_db/" + b + "_rgb.png", bufferedImageRGB, "png");
 		}
 	}
 


### PR DESCRIPTION
## Summary
- fix resource handler for `image_db` paths
- save generated images under `src/main/resources/image_db`
- ensure image directory exists before generating

## Testing
- `mvn -q -DskipTests=true package` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6844193b8504832a82e74931eed2cc2b