### PR TITLE
Implement favorite images saving

### DIFF
--- a/src/main/java/nic/com/Diplomka/controller/IndexViewController.java
+++ b/src/main/java/nic/com/Diplomka/controller/IndexViewController.java
@@ -4,8 +4,15 @@ import nic.com.Diplomka.service.GeneratorService;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 
 
 import java.util.ArrayList;
@@ -28,6 +35,39 @@ public class IndexViewController {
         GeneratorService.generateImages();
         modelAndView.setViewName("redirect:/");
         return modelAndView;
+    }
+
+    @PostMapping("/saveFavorites")
+    public String saveFavorites(
+            @RequestParam(value = "selectedImages", required = false) List<String> selectedImages
+    ) {
+        if (selectedImages != null && !selectedImages.isEmpty()) {
+            Path favDir = Paths.get("favorite_images");
+            if (!Files.exists(favDir)) {
+                try {
+                    Files.createDirectories(favDir);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+            for (String img : selectedImages) {
+                Path srcPath = Paths.get(img);
+                if (!Files.exists(srcPath)) {
+                    srcPath = Paths.get("src/main/resources").resolve(img);
+                }
+                if (!Files.exists(srcPath)) {
+                    srcPath = Paths.get("image").resolve(Paths.get(img).getFileName());
+                }
+                if (Files.exists(srcPath)) {
+                    try {
+                        Files.copy(srcPath, favDir.resolve(srcPath.getFileName()), StandardCopyOption.REPLACE_EXISTING);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
+        return "redirect:/";
     }
 
 

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -58,22 +58,22 @@
 
     <section class="service-area">
         <div class="container">
-            <div class="row">
-
-                <tr th:each="imageDir : ${imageList}">
-                    <div class="col-md-6">
+            <form method="post" th:action="@{/saveFavorites}">
+                <div class="row">
+                    <div th:each="imageDir : ${imageList}" class="col-md-6">
                         <a style="display:block"
-                           th:href="@{/selectedImage(
-                               imageDir=${imageDir})}">
+                           th:href="@{/selectedImage(imageDir=${imageDir})}">
                             <div class="single-service">
                                 <img style="width: inherit; height: inherit;"
                                      th:src="${imageDir}"/>
                             </div>
                         </a>
+                        <input type="checkbox" name="selectedImages"
+                               th:value="${imageDir}"/>
                     </div>
-                </tr>
-
-            </div>
+                </div>
+                <button type="submit" class="btn btn-primary mt-3">Save selected</button>
+            </form>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary
- allow selecting images on the main page with checkboxes
- add new endpoint to save chosen images into `favorite_images` directory
- keep directory under version control using `.gitkeep`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68441a29cd54832aa721792faa928a61