### PR TITLE
Update dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.1.RELEASE</version>
+        <version>3.5.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>ua.nic</groupId>
@@ -16,7 +16,7 @@
     <name>DiplomProject</name>
     <description>Demo project for Spring Boot</description>
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
     </properties>
     <dependencies>
         <dependency>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>1.6.2</version>
+            <version>1.12.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -41,7 +41,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-rest</artifactId>
-            <version>2.1.3.RELEASE</version>
         </dependency>
     </dependencies>
     <build>
@@ -53,7 +52,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.8</version>
+                <version>0.8.13</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
## Summary
- update Spring Boot to 3.5.0 and set Java 17
- update junit-platform-launcher to 1.12.2
- use parent-managed version for spring-boot-starter-data-rest
- update jacoco-maven-plugin to 0.8.13

## Testing
- `mvn test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68442484a014832a856398f525154fc8