### PR TITLE
Update image grid and generation count

### DIFF
--- a/src/main/java/nic/com/Diplomka/Main.java
+++ b/src/main/java/nic/com/Diplomka/Main.java
@@ -40,7 +40,7 @@ public class Main {
 	}
 
 	public static void main(String[] args) {
-		int builderCount = 15;
+                int builderCount = 16;
 		Scanner scanner = new Scanner(System.in);
 
 		NeuralNetwork neuralNetwork = new NeuralNetwork(builderCount, 3, 3);

--- a/src/main/java/nic/com/Diplomka/controller/IndexViewController.java
+++ b/src/main/java/nic/com/Diplomka/controller/IndexViewController.java
@@ -73,7 +73,7 @@ public class IndexViewController {
 
     private List<String> getImageList() {
         List<String> imageList = new ArrayList<>();
-        for (int i = 0; i < 15; i++) {
+        for (int i = 0; i < GeneratorService.builderCount; i++) {
             imageList.add("image_db/" + i + "_hsb.png");
             imageList.add("image_db/" + i + "_rgb.png");
         }

--- a/src/main/java/nic/com/Diplomka/service/GeneratorService.java
+++ b/src/main/java/nic/com/Diplomka/service/GeneratorService.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 public class GeneratorService {
 	public static final int heightImage = 250;
 	public static final int weightImage = 250;
-	public static int builderCount = 15;
+        public static int builderCount = 16;
 	public static NeuralNetwork neuralNetwork = new NeuralNetwork(builderCount, 3, 3);
 
 	public static double calculateDistanceBetweenPoints(double x1, double y1, double x2, double y2) {

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -60,7 +60,7 @@
         <div class="container">
             <form method="post" th:action="@{/saveFavorites}">
                 <div class="row">
-                    <div th:each="imageDir : ${imageList}" class="col-md-6">
+                    <div th:each="imageDir : ${imageList}" class="col-md-3">
                         <a style="display:block"
                            th:href="@{/selectedImage(imageDir=${imageDir})}">
                             <div class="single-service">

--- a/src/test/java/GeneratorServiceBuilderCountTest.java
+++ b/src/test/java/GeneratorServiceBuilderCountTest.java
@@ -1,0 +1,10 @@
+import nic.com.Diplomka.service.GeneratorService;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GeneratorServiceBuilderCountTest {
+    @Test
+    void testBuilderCountIs16() {
+        assertEquals(16, GeneratorService.builderCount);
+    }
+}

--- a/src/test/java/IndexViewControllerTest.java
+++ b/src/test/java/IndexViewControllerTest.java
@@ -1,0 +1,19 @@
+import nic.com.Diplomka.controller.IndexViewController;
+import nic.com.Diplomka.service.GeneratorService;
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class IndexViewControllerTest {
+    @Test
+    void testImageListSize() {
+        IndexViewController controller = new IndexViewController();
+        Model model = new ExtendedModelMap();
+        controller.startPage(model);
+        List<String> imageList = (List<String>) model.getAttribute("imageList");
+        assertNotNull(imageList);
+        assertEquals(GeneratorService.builderCount * 2, imageList.size());
+    }
+}

--- a/src/test/java/TemplateColumnsTest.java
+++ b/src/test/java/TemplateColumnsTest.java
@@ -1,0 +1,15 @@
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TemplateColumnsTest {
+    @Test
+    void testTemplateUsesFourColumns() throws IOException {
+        String html = Files.readString(Paths.get("src/main/resources/templates/index.html"));
+        assertTrue(html.contains("col-md-3"));
+        assertFalse(html.contains("col-md-6"));
+    }
+}


### PR DESCRIPTION
## Summary
- show images in a 4 column grid
- generate 16 pairs of images instead of 15
- add tests for new builder count
- add tests for image list size and template columns

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684424d9334c832a831bc2d0fe8e8ca9