### PR TITLE
Ensure timestamp-based favorite filenames

### DIFF
--- a/src/main/java/nic/com/Diplomka/controller/IndexViewController.java
+++ b/src/main/java/nic/com/Diplomka/controller/IndexViewController.java
@@ -12,7 +12,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 
 import java.util.ArrayList;
@@ -59,8 +60,19 @@ public class IndexViewController {
                     srcPath = Paths.get("image").resolve(Paths.get(img).getFileName());
                 }
                 if (Files.exists(srcPath)) {
+                    String timestamp = LocalDateTime.now()
+                            .format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+                    String fileName = srcPath.getFileName().toString();
+                    int dotIndex = fileName.lastIndexOf('.');
+                    String newName;
+                    if (dotIndex != -1) {
+                        newName = fileName.substring(0, dotIndex) + "_" + timestamp + fileName.substring(dotIndex);
+                    } else {
+                        newName = fileName + "_" + timestamp;
+                    }
+                    Path dest = favDir.resolve(newName);
                     try {
-                        Files.copy(srcPath, favDir.resolve(srcPath.getFileName()), StandardCopyOption.REPLACE_EXISTING);
+                        Files.copy(srcPath, dest);
                     } catch (IOException e) {
                         e.printStackTrace();
                     }

--- a/src/test/java/SaveFavoritesUniqueNamesTest.java
+++ b/src/test/java/SaveFavoritesUniqueNamesTest.java
@@ -1,0 +1,39 @@
+import nic.com.Diplomka.controller.IndexViewController;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SaveFavoritesUniqueNamesTest {
+    @Test
+    void testUniqueNamesWhenSavingFavorites() throws IOException {
+        IndexViewController controller = new IndexViewController();
+        Path favDir = Paths.get("favorite_images");
+        if (Files.exists(favDir)) {
+            Files.walk(favDir)
+                    .filter(Files::isRegularFile)
+                    .forEach(p -> {
+                        try { Files.delete(p); } catch (IOException ignored) {}
+                    });
+        } else {
+            Files.createDirectories(favDir);
+        }
+
+        String imgPath = "image/0_hsb.png";
+        controller.saveFavorites(List.of(imgPath));
+        controller.saveFavorites(List.of(imgPath));
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(favDir)) {
+            int fileCount = 0;
+            for (Path p : stream) {
+                fileCount++;
+                String name = p.getFileName().toString();
+                assertTrue(name.startsWith("0_hsb_") && name.endsWith(".png"));
+            }
+            assertEquals(2, fileCount);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add timestamp-based suffix when saving favorite images
- verify saved filenames start with image name and include timestamp

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442fc1c0c4832aba0d34246eadfadd