### PR TITLE
Unify template layout

### DIFF
--- a/src/main/resources/templates/favorites.html
+++ b/src/main/resources/templates/favorites.html
@@ -1,35 +1,10 @@
 <!DOCTYPE html>
 <html lang="zxx" class="no-js" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="shortcut icon" href="template`s img/fav.png">
-    <meta name="author" content="Colorlib">
-    <meta name="description" content="">
-    <meta name="keywords" content="">
-    <meta charset="UTF-8">
-    <title>Favorites</title>
-    <link href="https://fonts.googleapis.com/css?family=Poppins:100,300,500,600" rel="stylesheet">
-    <link rel="stylesheet" href="../static/css/linearicons.css">
-    <link rel="stylesheet" href="../static/css/owl.carousel.css">
-    <link rel="stylesheet" href="../static/css/font-awesome.min.css">
-    <link rel="stylesheet" href="../static/css/nice-select.css">
-    <link rel="stylesheet" href="../static/css/magnific-popup.css">
-    <link rel="stylesheet" href="../static/css/bootstrap.css">
-    <link rel="stylesheet" href="../static/css/main.css">
-    <link rel="stylesheet" href="../static/css/style.css">
-</head>
+<head th:replace="fragments.html :: common_head('Favorites')"></head>
 <body>
 <div class="main-wrapper-first">
     <div class="hero-area relative">
-        <header>
-            <div class="container">
-                <div class="header-wrap">
-                    <div class="header-top d-flex justify-content-between align-items-center">
-                        <a href="/">Home</a>
-                    </div>
-                </div>
-            </div>
-        </header>
+        <header th:replace="fragments.html :: navbar"></header>
         <div class="banner-area">
             <div class="overlay overlay-bg"></div>
             <div class="container">
@@ -56,25 +31,8 @@
             </div>
         </div>
     </section>
-    <footer class="footer-area relative">
-        <div class="container">
-            <div class="footer-content d-flex flex-column align-items-center">
-                <div class="copy-right-text">Chernivtsi &copy;<script>document.write(new Date().getFullYear());</script>
-                    All rights not reserved | This site is made with <i class="fa fa-heart-o" aria-hidden="true"></i> by
-                    Serhii Stolenskyi
-                </div>
-            </div>
-        </div>
-    </footer>
+    <footer th:replace="fragments.html :: footer"></footer>
 </div>
-<script src="../static/js/vendor/jquery-2.2.4.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
-<script src="../static/js/vendor/bootstrap.min.js"></script>
-<script src="../static/js/jquery.ajaxchimp.min.js"></script>
-<script src="../static/js/owl.carousel.min.js"></script>
-<script src="../static/js/jquery.nice-select.min.js"></script>
-<script src="../static/js/parallax.min.js"></script>
-<script src="../static/js/jquery.magnific-popup.min.js"></script>
-<script src="../static/js/main.js"></script>
+<th:block th:replace="fragments.html :: scripts"></th:block>
 </body>
 </html>

--- a/src/main/resources/templates/fragments.html
+++ b/src/main/resources/templates/fragments.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="zxx" xmlns:th="http://www.thymeleaf.org">
+<head th:fragment="common_head(title)">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta charset="UTF-8">
+    <title th:text="${title}">Pemodule</title>
+    <link href="https://fonts.googleapis.com/css?family=Poppins:100,300,500,600" rel="stylesheet">
+    <link rel="stylesheet" th:href="@{/css/linearicons.css}">
+    <link rel="stylesheet" th:href="@{/css/owl.carousel.css}">
+    <link rel="stylesheet" th:href="@{/css/font-awesome.min.css}">
+    <link rel="stylesheet" th:href="@{/css/nice-select.css}">
+    <link rel="stylesheet" th:href="@{/css/magnific-popup.css}">
+    <link rel="stylesheet" th:href="@{/css/bootstrap.css}">
+    <link rel="stylesheet" th:href="@{/css/main.css}">
+    <link rel="stylesheet" th:href="@{/css/style.css}">
+</head>
+<body>
+<div th:fragment="navbar">
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+        <div class="container">
+            <a class="navbar-brand" th:href="@{/}">Pemodule</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
+                    aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item"><a class="nav-link" th:href="@{/}">Home</a></li>
+                    <li class="nav-item"><a class="nav-link" th:href="@{/favorites}">Favorites</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+</div>
+
+<footer class="footer-area relative" th:fragment="footer">
+    <div class="container">
+        <div class="footer-content d-flex flex-column align-items-center">
+            <div class="copy-right-text">
+                Chernivtsi &copy;<script>document.write(new Date().getFullYear());</script>
+                All rights not reserved | This site is made with <i class="fa fa-heart-o" aria-hidden="true"></i> by
+                Serhii Stolenskyi
+            </div>
+        </div>
+    </div>
+</footer>
+
+<div th:fragment="scripts">
+    <script th:src="@{/js/vendor/jquery-2.2.4.min.js}"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"
+            integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4"
+            crossorigin="anonymous"></script>
+    <script th:src="@{/js/vendor/bootstrap.min.js}"></script>
+    <script th:src="@{/js/jquery.ajaxchimp.min.js}"></script>
+    <script th:src="@{/js/owl.carousel.min.js}"></script>
+    <script th:src="@{/js/jquery.nice-select.min.js}"></script>
+    <script th:src="@{/js/parallax.min.js}"></script>
+    <script th:src="@{/js/jquery.magnific-popup.min.js}"></script>
+    <script th:src="@{/js/main.js}"></script>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,46 +1,10 @@
 <!DOCTYPE html>
 <html lang="zxx" class="no-js" xmlns:th="http://www.thymeleaf.org">
-<head>
-    <!-- Mobile Specific Meta -->
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <!-- Favicon-->
-    <link rel="shortcut icon" href="template`s img/fav.png">
-    <!-- Author Meta -->
-    <meta name="author" content="Colorlib">
-    <!-- Meta Description -->
-    <meta name="description" content="">
-    <!-- Meta Keyword -->
-    <meta name="keywords" content="">
-    <!-- meta character set -->
-    <meta charset="UTF-8">
-    <!-- Site Title -->
-    <title>Pemodule</title>
-
-    <link href="https://fonts.googleapis.com/css?family=Poppins:100,300,500,600" rel="stylesheet">
-    <!--
-    CSS
-    ============================================= -->
-    <link rel="stylesheet" href="css/linearicons.css">
-    <link rel="stylesheet" href="css/owl.carousel.css">
-    <link rel="stylesheet" href="css/font-awesome.min.css">
-    <link rel="stylesheet" href="css/nice-select.css">
-    <link rel="stylesheet" href="css/magnific-popup.css">
-    <link rel="stylesheet" href="css/bootstrap.css">
-    <link rel="stylesheet" href="css/main.css">
-    <link rel="stylesheet" href="css/style.css">
-</head>
+<head th:replace="fragments.html :: common_head('Pemodule')"></head>
 <body>
 <div class="main-wrapper-first">
     <div class="hero-area relative">
-        <header>
-            <div class="container">
-                <div class="header-wrap">
-                    <div class="header-top d-flex justify-content-between align-items-center">
-                        <a href="/favorites">Favorites</a>
-                    </div>
-                </div>
-            </div>
-        </header>
+        <header th:replace="fragments.html :: navbar"></header>
         <div class="banner-area">
             <div class="overlay overlay-bg"></div>
             <div class="container">
@@ -80,32 +44,11 @@
     </section>
 
 
-    <footer class="footer-area relative">
-        <div class="container">
-            <div class="footer-content d-flex flex-column align-items-center">
-
-                <div class="copy-right-text">Chernivtsi &copy;<script>document.write(new Date().getFullYear());</script>
-                    All rights not reserved | This site is made with <i class="fa fa-heart-o" aria-hidden="true"></i> by
-                    Serhii Stolenskyi
-                </div>
-
-            </div>
-        </div>
-    </footer>
+    <footer th:replace="fragments.html :: footer"></footer>
 
 </div>
 
 
-<script src="js/vendor/jquery-2.2.4.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"
-        integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4"
-        crossorigin="anonymous"></script>
-<script src="js/vendor/bootstrap.min.js"></script>
-<script src="js/jquery.ajaxchimp.min.js"></script>
-<script src="js/owl.carousel.min.js"></script>
-<script src="js/jquery.nice-select.min.js"></script>
-<script src="js/parallax.min.js"></script>
-<script src="js/jquery.magnific-popup.min.js"></script>
-<script src="js/main.js"></script>
+<th:block th:replace="fragments.html :: scripts"></th:block>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- centralize page layout in `fragments.html`
- use the common fragments for `/` and `/favorites`

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844320cc4bc832aa613007e53f96843