### PR TITLE
Implement favorites neural network save/load

### DIFF
--- a/src/main/java/nic/com/Diplomka/controller/IndexViewController.java
+++ b/src/main/java/nic/com/Diplomka/controller/IndexViewController.java
@@ -1,8 +1,7 @@
 package nic.com.Diplomka.controller;
 
 import nic.com.Diplomka.service.GeneratorService;
-import nic.com.Diplomka.neuralNetwork.NeuralBuilder;
-import nic.com.Diplomka.neuralNetwork.NeuralNetwork;
+import nic.com.Diplomka.service.FavoriteService;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,21 +9,16 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-
-
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Controller
 public class IndexViewController {
+    private final FavoriteService favoriteService;
+
+    public IndexViewController(FavoriteService favoriteService) {
+        this.favoriteService = favoriteService;
+    }
     @GetMapping("/")
     public String startPage (Model model) {
         model.addAttribute("imageList", getImageList());
@@ -46,47 +40,7 @@ public class IndexViewController {
     public String saveFavorites(
             @RequestParam(value = "selectedImages", required = false) List<String> selectedImages
     ) {
-        if (selectedImages != null && !selectedImages.isEmpty()) {
-            Path favDir = Paths.get("src/main/resources/favorite_images");
-            if (!Files.exists(favDir)) {
-                try {
-                    Files.createDirectories(favDir);
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-            for (String img : selectedImages) {
-                Path srcPath = Paths.get(img);
-                if (!Files.exists(srcPath)) {
-                    srcPath = Paths.get("src/main/resources").resolve(img);
-                }
-                if (!Files.exists(srcPath)) {
-                    srcPath = Paths.get("image").resolve(Paths.get(img).getFileName());
-                }
-                if (Files.exists(srcPath)) {
-                    String timestamp = LocalDateTime.now()
-                            .format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
-                    String fileName = srcPath.getFileName().toString();
-                    int dotIndex = fileName.lastIndexOf('.');
-                    String newName;
-                    if (dotIndex != -1) {
-                        newName = fileName.substring(0, dotIndex) + "_" + timestamp + fileName.substring(dotIndex);
-                    } else {
-                        newName = fileName + "_" + timestamp;
-                    }
-                    Path dest = favDir.resolve(newName);
-                    try {
-                        Files.copy(srcPath, dest);
-                        String builderName = newName.replaceAll("\\.png$", ".ser");
-                        int idx = fileName.replaceAll("\\D", "").isEmpty() ? 0 : Integer.parseInt(fileName.replaceAll("\\D", ""));
-                        NeuralBuilder builder = GeneratorService.neuralNetwork.getNeuralBuilder(idx);
-                        NeuralNetwork.serializebleObject(builder, favDir.resolve(builderName).toString());
-                    } catch (IOException e) {
-                        e.printStackTrace();
-                    }
-                }
-            }
-        }
+        favoriteService.saveFavorites(selectedImages);
         return "redirect:/";
     }
 
@@ -103,7 +57,7 @@ public class IndexViewController {
 
     @GetMapping("/favorites")
     public String favoritesPage(Model model) {
-        model.addAttribute("favoriteImages", getFavoriteImageList());
+        model.addAttribute("favoriteImages", favoriteService.listFavorites());
         return "favorites.html";
     }
 
@@ -112,36 +66,9 @@ public class IndexViewController {
             @RequestParam() String imageDir,
             ModelAndView modelAndView
     ) {
-        Path neuralPath = Paths.get("src/main/resources").resolve(imageDir.replace(".png", ".ser"));
-        if (!Files.exists(neuralPath)) {
-            neuralPath = Paths.get(imageDir).resolveSibling(neuralPath.getFileName());
-        }
-        if (Files.exists(neuralPath)) {
-            NeuralBuilder builder = (NeuralBuilder) NeuralNetwork.deserializebleObject(neuralPath.toString());
-            if (builder != null) {
-                GeneratorService.neuralNetwork.setNeuralBuilder(0, builder);
-                GeneratorService.neuralNetwork.evolute(0);
-                GeneratorService.generateImages();
-            }
-        }
+        favoriteService.loadFavorite(imageDir);
         modelAndView.setViewName("redirect:/");
         return modelAndView;
-    }
-
-    private List<String> getFavoriteImageList() {
-        Path dir = Paths.get("src/main/resources/favorite_images");
-        if (!Files.exists(dir)) {
-            return new ArrayList<>();
-        }
-        try (Stream<Path> stream = Files.list(dir)) {
-            return stream
-                    .filter(p -> Files.isRegularFile(p) && p.getFileName().toString().endsWith(".png"))
-                    .map(p -> "favorite_images/" + p.getFileName().toString())
-                    .collect(Collectors.toList());
-        } catch (IOException e) {
-            e.printStackTrace();
-            return new ArrayList<>();
-        }
     }
 
 

--- a/src/main/java/nic/com/Diplomka/neuralNetwork/NeuralNetwork.java
+++ b/src/main/java/nic/com/Diplomka/neuralNetwork/NeuralNetwork.java
@@ -72,6 +72,22 @@ public class NeuralNetwork implements Serializable {
         return deserializebleObj;
     }
 
+    private static <T extends Serializable> T cloneObject(T obj) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+                oos.writeObject(obj);
+            }
+            try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+                @SuppressWarnings("unchecked")
+                T clone = (T) ois.readObject();
+                return clone;
+            }
+        } catch (IOException | ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public Color getRgbColor(int index) {
         int[] returnIndexs = neuralBuilders[index].getReturnIndexs();
         List<Neuron> neuronList = neuralBuilders[index].getNeuronList();
@@ -115,11 +131,11 @@ public class NeuralNetwork implements Serializable {
             System.out.println(neuralBuilders[index].changed);
             System.out.println();
         }
-        serializebleObject(neuralBuilders[index], "neuralBilder.obj");
-        neuralBuilders[0] = neuralBuilders[index];
+        NeuralBuilder base = neuralBuilders[index];
+        neuralBuilders[0] = base;
         for (int i = 1; i < neuralBuilders.length; i++) {
             String changed = "";
-            NeuralBuilder cloneNB = (NeuralBuilder) deserializebleObject("neuralBilder.obj");
+            NeuralBuilder cloneNB = cloneObject(base);
             // потрібно трохи змінити нейронну мережу
             /** Ф-ції, які рандомом змінюють нейронну мережу
              * addNewRandomNeuron - 0;

--- a/src/main/java/nic/com/Diplomka/neuralNetwork/NeuralNetwork.java
+++ b/src/main/java/nic/com/Diplomka/neuralNetwork/NeuralNetwork.java
@@ -21,6 +21,14 @@ public class NeuralNetwork implements Serializable {
                 evolute(0);
         }
 
+        public NeuralBuilder getNeuralBuilder(int index) {
+                return neuralBuilders[index];
+        }
+
+        public void setNeuralBuilder(int index, NeuralBuilder builder) {
+                neuralBuilders[index] = builder;
+        }
+
     public static void serializebleObject(Object obj, String fileName) {
         ObjectOutputStream objectOutputStream = null;
         try {

--- a/src/main/java/nic/com/Diplomka/service/FavoriteService.java
+++ b/src/main/java/nic/com/Diplomka/service/FavoriteService.java
@@ -1,0 +1,97 @@
+package nic.com.Diplomka.service;
+
+import nic.com.Diplomka.neuralNetwork.NeuralBuilder;
+import nic.com.Diplomka.neuralNetwork.NeuralNetwork;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+public class FavoriteService {
+    private static final Path FAVORITES_DIR = Paths.get("src/main/resources/favorite_images");
+
+    public FavoriteService() {
+        try {
+            if (!Files.exists(FAVORITES_DIR)) {
+                Files.createDirectories(FAVORITES_DIR);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void saveFavorites(List<String> selectedImages) {
+        if (selectedImages == null || selectedImages.isEmpty()) {
+            return;
+        }
+        for (String img : selectedImages) {
+            Path srcPath = resolveSource(img);
+            if (Files.exists(srcPath)) {
+                String timestamp = LocalDateTime.now()
+                        .format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+                String fileName = srcPath.getFileName().toString();
+                int dotIndex = fileName.lastIndexOf('.');
+                String newName = dotIndex != -1
+                        ? fileName.substring(0, dotIndex) + "_" + timestamp + fileName.substring(dotIndex)
+                        : fileName + "_" + timestamp;
+                Path dest = FAVORITES_DIR.resolve(newName);
+                try {
+                    Files.copy(srcPath, dest);
+                    String builderName = newName.replaceAll("\\.png$", ".ser");
+                    int idx = fileName.replaceAll("\\D", "").isEmpty() ? 0 : Integer.parseInt(fileName.replaceAll("\\D", ""));
+                    NeuralBuilder builder = GeneratorService.neuralNetwork.getNeuralBuilder(idx);
+                    NeuralNetwork.serializebleObject(builder, FAVORITES_DIR.resolve(builderName).toString());
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    private Path resolveSource(String img) {
+        Path srcPath = Paths.get(img);
+        if (!Files.exists(srcPath)) {
+            srcPath = Paths.get("src/main/resources").resolve(img);
+        }
+        if (!Files.exists(srcPath)) {
+            srcPath = Paths.get("image").resolve(Paths.get(img).getFileName());
+        }
+        return srcPath;
+    }
+
+    public List<String> listFavorites() {
+        if (!Files.exists(FAVORITES_DIR)) {
+            return new ArrayList<>();
+        }
+        try (Stream<Path> stream = Files.list(FAVORITES_DIR)) {
+            return stream.filter(p -> Files.isRegularFile(p) && p.getFileName().toString().endsWith(".png"))
+                    .map(p -> "favorite_images/" + p.getFileName().toString())
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            e.printStackTrace();
+            return new ArrayList<>();
+        }
+    }
+
+    public void loadFavorite(String imageDir) {
+        Path neuralPath = Paths.get("src/main/resources").resolve(imageDir.replace(".png", ".ser"));
+        if (!Files.exists(neuralPath)) {
+            neuralPath = Paths.get(imageDir).resolveSibling(neuralPath.getFileName());
+        }
+        if (Files.exists(neuralPath)) {
+            NeuralBuilder builder = (NeuralBuilder) NeuralNetwork.deserializebleObject(neuralPath.toString());
+            if (builder != null) {
+                GeneratorService.neuralNetwork.setNeuralBuilder(0, builder);
+                GeneratorService.neuralNetwork.evolute(0);
+                GeneratorService.generateImages();
+            }
+        }
+    }
+}

--- a/src/main/resources/templates/favorites.html
+++ b/src/main/resources/templates/favorites.html
@@ -49,9 +49,11 @@
         <div class="container-fluid">
             <div class="row">
                 <div th:each="img : ${favoriteImages}" class="col-md-3 image-col">
-                    <div class="single-service">
-                        <img class="img-fluid gallery-img" th:src="${img}"/>
-                    </div>
+                    <a th:href="@{/favoriteSelectedImage(imageDir=${img})}" style="display:block">
+                        <div class="single-service">
+                            <img class="img-fluid gallery-img" th:src="${img}"/>
+                        </div>
+                    </a>
                 </div>
             </div>
         </div>

--- a/src/test/java/SaveFavoritesNetworkFileTest.java
+++ b/src/test/java/SaveFavoritesNetworkFileTest.java
@@ -1,39 +1,32 @@
 import nic.com.Diplomka.controller.IndexViewController;
 import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
 import java.nio.file.*;
 import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.*;
 
-public class SaveFavoritesUniqueNamesTest {
+public class SaveFavoritesNetworkFileTest {
     @Test
-    void testUniqueNamesWhenSavingFavorites() throws IOException {
+    void testNetworkFileCreated() throws IOException {
         IndexViewController controller = new IndexViewController();
         Path favDir = Paths.get("favorite_images");
         if (Files.exists(favDir)) {
             Files.walk(favDir)
                     .filter(Files::isRegularFile)
-                    .forEach(p -> {
-                        try { Files.delete(p); } catch (IOException ignored) {}
-                    });
+                    .forEach(p -> { try { Files.delete(p); } catch (IOException ignored) {} });
         } else {
             Files.createDirectories(favDir);
         }
-
         String imgPath = "image/0_hsb.png";
         controller.saveFavorites(List.of(imgPath));
-        controller.saveFavorites(List.of(imgPath));
-
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(favDir, "*.png")) {
-            int fileCount = 0;
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(favDir, "*.ser")) {
+            int count = 0;
             for (Path p : stream) {
-                fileCount++;
+                count++;
                 String name = p.getFileName().toString();
-                assertTrue(name.startsWith("0_hsb_") && name.endsWith(".png"));
+                assertTrue(name.startsWith("0_hsb_") && name.endsWith(".ser"));
             }
-            assertEquals(2, fileCount);
+            assertEquals(1, count);
         }
     }
 }

--- a/src/test/java/SaveFavoritesNetworkFileTest.java
+++ b/src/test/java/SaveFavoritesNetworkFileTest.java
@@ -1,4 +1,5 @@
 import nic.com.Diplomka.controller.IndexViewController;
+import nic.com.Diplomka.service.FavoriteService;
 import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.*;
@@ -8,8 +9,9 @@ import static org.junit.jupiter.api.Assertions.*;
 public class SaveFavoritesNetworkFileTest {
     @Test
     void testNetworkFileCreated() throws IOException {
-        IndexViewController controller = new IndexViewController();
-        Path favDir = Paths.get("favorite_images");
+        FavoriteService service = new FavoriteService();
+        IndexViewController controller = new IndexViewController(service);
+        Path favDir = Paths.get("src/main/resources/favorite_images");
         if (Files.exists(favDir)) {
             Files.walk(favDir)
                     .filter(Files::isRegularFile)

--- a/src/test/java/SaveFavoritesUniqueNamesTest.java
+++ b/src/test/java/SaveFavoritesUniqueNamesTest.java
@@ -1,4 +1,5 @@
 import nic.com.Diplomka.controller.IndexViewController;
+import nic.com.Diplomka.service.FavoriteService;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -10,8 +11,9 @@ import static org.junit.jupiter.api.Assertions.*;
 public class SaveFavoritesUniqueNamesTest {
     @Test
     void testUniqueNamesWhenSavingFavorites() throws IOException {
-        IndexViewController controller = new IndexViewController();
-        Path favDir = Paths.get("favorite_images");
+        FavoriteService service = new FavoriteService();
+        IndexViewController controller = new IndexViewController(service);
+        Path favDir = Paths.get("src/main/resources/favorite_images");
         if (Files.exists(favDir)) {
             Files.walk(favDir)
                     .filter(Files::isRegularFile)


### PR DESCRIPTION
## Summary
- save neural network builders along with favorite images
- allow loading a network when clicking a favorite image
- show only PNGs in favorites list
- make favorites clickable
- add tests for saving network files and update unique names test

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684436ade140832a8f814850ef79652e