### PR TITLE
Refactor cloning without serialization

### DIFF
--- a/src/main/java/nic/com/Diplomka/neuralNetwork/NeuralBuilder.java
+++ b/src/main/java/nic/com/Diplomka/neuralNetwork/NeuralBuilder.java
@@ -18,8 +18,26 @@ public class NeuralBuilder implements Serializable {
 	private int[] returnIndexs;
 
 
-	public NeuralBuilder() {
-	}
+        public NeuralBuilder() {
+        }
+
+        public NeuralBuilder(NeuralBuilder other) {
+                this.changed = other.changed;
+                this.neuronList = new ArrayList<>();
+                for (Neuron n : other.neuronList) {
+                        this.neuronList.add(n.copy());
+                }
+                this.inputIndexListByNeuronId = new HashMap<>();
+                for (Map.Entry<Integer, Set<Integer>> e : other.inputIndexListByNeuronId.entrySet()) {
+                        this.inputIndexListByNeuronId.put(e.getKey(), new HashSet<>(e.getValue()));
+                }
+                this.allIndexSet = new HashSet<>(other.allIndexSet);
+                this.returnIndexs = other.returnIndexs != null ? Arrays.copyOf(other.returnIndexs, other.returnIndexs.length) : null;
+        }
+
+        public NeuralBuilder copy() {
+                return new NeuralBuilder(this);
+        }
 
 	public NeuralBuilder(int neuronCount, int firstInputCount) {
 		neuronList = new ArrayList<>();

--- a/src/main/java/nic/com/Diplomka/neuralNetwork/NeuralNetwork.java
+++ b/src/main/java/nic/com/Diplomka/neuralNetwork/NeuralNetwork.java
@@ -72,21 +72,6 @@ public class NeuralNetwork implements Serializable {
         return deserializebleObj;
     }
 
-    private static <T extends Serializable> T cloneObject(T obj) {
-        try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
-                oos.writeObject(obj);
-            }
-            try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-                @SuppressWarnings("unchecked")
-                T clone = (T) ois.readObject();
-                return clone;
-            }
-        } catch (IOException | ClassNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     public Color getRgbColor(int index) {
         int[] returnIndexs = neuralBuilders[index].getReturnIndexs();
@@ -135,7 +120,7 @@ public class NeuralNetwork implements Serializable {
         neuralBuilders[0] = base;
         for (int i = 1; i < neuralBuilders.length; i++) {
             String changed = "";
-            NeuralBuilder cloneNB = cloneObject(base);
+            NeuralBuilder cloneNB = base.copy();
             // потрібно трохи змінити нейронну мережу
             /** Ф-ції, які рандомом змінюють нейронну мережу
              * addNewRandomNeuron - 0;

--- a/src/main/java/nic/com/Diplomka/neuralNetwork/Neuron.java
+++ b/src/main/java/nic/com/Diplomka/neuralNetwork/Neuron.java
@@ -3,24 +3,37 @@ package nic.com.Diplomka.neuralNetwork;
 import nic.com.Diplomka.enums.ActivationFunction;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Random;
 
 public class Neuron implements Serializable {
-	private double inputs[];
-	private double weights[];
-	private double output;
-	private int id;
+        private double[] inputs;
+        private double[] weights;
+        private double output;
+        private int id;
 
-	private ActivationFunction activationFunction;
+        private ActivationFunction activationFunction;
 
 	public Neuron() {
 	}
 
-	public Neuron(double[] inputs, double[] weights, ActivationFunction activationFunction) {
-		this.inputs = inputs;
-		this.weights = weights;
-		this.activationFunction = activationFunction;
-	}
+        public Neuron(double[] inputs, double[] weights, ActivationFunction activationFunction) {
+                this.inputs = inputs;
+                this.weights = weights;
+                this.activationFunction = activationFunction;
+        }
+
+        public Neuron(Neuron other) {
+                this.inputs = other.inputs != null ? Arrays.copyOf(other.inputs, other.inputs.length) : null;
+                this.weights = other.weights != null ? Arrays.copyOf(other.weights, other.weights.length) : null;
+                this.output = other.output;
+                this.id = other.id;
+                this.activationFunction = other.activationFunction;
+        }
+
+        public Neuron copy() {
+                return new Neuron(this);
+        }
 
 	public Neuron(double[] inputs) {
 		this.inputs = inputs;


### PR DESCRIPTION
## Summary
- stop using Java serialization for cloning neural structures
- add explicit copy constructors for `Neuron` and `NeuralBuilder`
- remove the old serialization-based cloning logic

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68443f87d1c8832a8009de8d654bffce